### PR TITLE
Fix usage pages and interface numbers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,9 @@ impl DeviceImplementation for WootingOne {
             #[cfg(linux)]
             usage_page: 0,
             #[cfg(not(linux))]
-            usage_page: 0x54FF,
+            usage_page: 0x1337,
 
-            interface_n: 6,
+            interface_n: 2,
         }
     }
 
@@ -137,9 +137,9 @@ impl DeviceImplementation for WootingTwo {
             #[cfg(linux)]
             usage_page: 0,
             #[cfg(not(linux))]
-            usage_page: 0x54FF,
+            usage_page: 0x1337,
 
-            interface_n: 6,
+            interface_n: 2,
         }
     }
 


### PR DESCRIPTION
Perhaps this needs to be behind a platform-specific flag, but these are the usage pages and interface numbers used by the Wootility and fix MacOS (at least).

Let me know if this is Darwin-only and I will adjust as necessary.